### PR TITLE
Implement setTweak function and update the wrapper URL parameter append process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ As of version 1.1.0, Cleverbot tweaking parameters have been implemented to this
 
 Each of these values must be an integer between 0 and 100. If left undeclared, whatever Cleverbot defaults to will be used.  
 
-Only the first example under Usage section below has been updated to show the use of these tweaks. They will be used in the same object as the `cs` parameter.
+Only the first example under Usage section below has been updated to show the use of these tweaks. As of version 1.2.0, these tweaks can be altered with the `setTweak` function. 
+Previously they were used in the same object as the `cs` parameter, but that approach, while still supported, is now discouraged.
 
 If the introduction of these changes broke things for you, please create an issue on the [GitHub page](https://github.com/FaurinFox/Cleverbot/issues) in order to let me know about them.
 
@@ -50,17 +51,21 @@ import Cleverbot from '@faurinfox/cleverbot';
           // This is also demonstrating how to use this with async function and await
             try {
                 // As of v1.1.0, the same object we use to pass cs(Str), can also be
-                // used to set Cleverbot tweaks you wish to use. We will
-                // set all three in the below line, to 70, 50, 50.
+                // used to set Cleverbot tweaks you wish to use.
+                // Below is an example of doing just that:
+                /*
                 let CbTweaks = {wackiness: 70, talkativeness: 50, attentiveness: 50};
-                // And then use them in the options
                 let reply = await CB.query(inputMsg, {cs: csStr, ...CbTweaks});
-                // We could also just pass them normally as shown below, but its more lengthy, so i prefer the one above instead. 
-                //  let reply = await CB.query(inputMsg, {cs: csStr, wackiness: 70, talkativeness: 50, attentiveness: 50});
-                // I may later on make this object approach work the same internally
-                // And keep the option to use it like this
-                // but also create something like CB.setTweak('wacky', 70);
-                // which at the moment doesn't exist but it may later.
+                */
+                // However, as of v1.2.0, the function approach is preferred.
+                // while the object approach introduced in v1.1.0
+                // is still supported, it is now discouraged as the new function one is preferred.
+                CB.setTweak('wackiness', 70);
+                CB.setTweak('talkativeness', 50);
+                CB.setTweak('attentiveness', 50);
+                // Alternatively, there is also
+                // CB.setWackiness(70). Both do the same thing. Similar functions also exist for the other two tweaks.
+                let reply = await CB.query(inputMsg, {cs: csStr});
                 // CB.query used above will return a JSON with the reply received from Cleverbot API, as well as an added 'URL' property should you need to know the URL that was called to receive that response
                 // We do not need the entire JSON, only the reply, thus use .output
                 console.log("Reply: "+reply.output);

--- a/index.mjs
+++ b/index.mjs
@@ -20,11 +20,91 @@
  */
 
 import inquiry from './lib/query.mjs';
+import vars from './lib/vars.mjs'
+
+function validateTweaks(tweakNumber, optionName, optionValue) {
+	if (typeof optionValue == "number") {
+		if (Number.isInteger(optionValue)) {
+			if (optionValue >= 0 && optionValue <= 100) {
+				vars.change('tweak'+tweakNumber, optionValue);
+			} else {
+				return vars.errors.handler('optionsObjKeyInvalidValueRange', {key: optionName, val: optionValue, range: '0-100'});
+			}
+		} else {
+			return vars.errors.handler('optionsObjKeyNotInteger', optionName);
+		}
+	} else {
+		return vars.errors.handler('optionsObjKeyNotNumber', optionName);
+	}
+}
 
 class Cleverbot {
     query;
     constructor(args) {
         this.query = inquiry(args);
+    }
+    setTweak(tweakName, value) {
+        if (typeof tweakName == 'string') {
+            switch (tweakName.toLowerCase()) {
+                case "wackiness":
+                    validateTweaks(1, 'wackiness', value);
+                    break;
+                case "talkativeness":
+                    validateTweaks(2, 'talkativeness', value);
+                    break;
+                case "attentiveness":
+                    validateTweaks(3, 'attentiveness', value);
+                    break;
+                default:
+                    return vars.errors.handler('invalidTweak', value);
+            }
+        }else{
+            return vars.errors.handler('optionsObjKeyNotString', 'tweakName');
+        }
+    }
+    setWackiness(value) {
+        validateTweaks(1, 'wackiness', value);
+    }
+    setTalkativeness(value) {
+        validateTweaks(2, 'talkativeness', value);
+    }
+    setAttentiveness(value) {
+        validateTweaks(3, 'attentiveness', value);
+    }
+    getTweak(tweakName, callback) {
+        return new Promise(async function (resolve, reject) {
+            if (typeof tweakName == 'string') {
+                switch (tweakName.toLowerCase()) {
+                    case "wackiness":
+                        return callback ? callback(vars.tweak1) : resolve(vars.tweak1);
+                    case "talkativeness":
+                        return callback ? callback(vars.tweak2) : resolve(vars.tweak2);
+                    case "attentiveness":
+                        return callback ? callback(vars.tweak3) : resolve(vars.tweak3);
+                    default:
+                        return callback ? callback(vars.errors.handler('invalidTweak', value)) : reject(vars.errors.handler('invalidTweak', value));
+                }
+            }else{
+                return  callback ? callback(vars.errors.handler('optionsObjKeyNotString', 'tweakName')) : reject(vars.errors.handler('optionsObjKeyNotString', 'tweakName'));
+            }
+        });
+    }
+    getTweaks(callback) {
+        return new Promise(async function (resolve, reject) {
+            let tempObj = {};
+            try {
+                tempObj = {
+                    'wackiness': vars.tweak1,
+                    'talkativeness': vars.tweak2,
+                    'attentiveness': vars.tweak3
+                }
+                return callback ? callback(tempObj) : resolve(tempObj)
+            } catch (error) {
+                return callback ? callback(error) : reject(error);
+            } finally {
+                tempObj = {};
+            }
+        });
     }
 }
 

--- a/lib/query.mjs
+++ b/lib/query.mjs
@@ -49,6 +49,7 @@ import vars from './vars.mjs'
 
 const BASE_URL = vars.baseURL;
 const CS = vars.csStr;
+const WS = vars.wrapper;
 const TS = vars.tweakStr;
 
 function inquiry(settings) {
@@ -57,7 +58,6 @@ function inquiry(settings) {
 			let requestURL = BASE_URL
 				.replace(vars.apiKey, settings.key)
 				.replace(vars.input, encodeURIComponent(input))
-				.replace(vars.wrapper, encodeURIComponent(vars.wrapperStr));
 			function validateTweaks(tweakNumber, optionName, optionValue) {
 				if (typeof optionValue == "number") {
 					if (Number.isInteger(optionValue)) {
@@ -74,6 +74,26 @@ function inquiry(settings) {
 					return callback ? callback(vars.errors.handler('optionsObjKeyNotNumber', optionName)) : reject(vars.errors.handler('optionsObjKeyNotNumber', optionName));
 				}
 			}
+			function checkVarTweaks() {
+				if (vars.tweak1 !== undefined && vars.tweak2 !== undefined && vars.tweak3 !== undefined || vars.tweak1 !== null && vars.tweak2 !== null && vars.tweak3 !== null) {
+					let tweaks = 1;
+					while (tweaks <= 3) {
+						switch ("tweak"+tweaks) {
+							case "tweak1":
+								validateTweaks(tweaks, 'wackiness', vars["tweak"+tweaks]);
+								break;
+							case "tweak2":
+								validateTweaks(tweaks, 'talkativeness', vars["tweak"+tweaks]);
+								break;
+							case "tweak3":
+								validateTweaks(tweaks, 'attentiveness', vars["tweak"+tweaks]);
+								break;
+						}
+						tweaks++;
+					}
+				}
+			}
+			checkVarTweaks();
 			if (options) {
 				if (typeof options == "object") {
 					if (options.wackiness) {
@@ -97,6 +117,7 @@ function inquiry(settings) {
 				}
 			}
 			try {
+				requestURL += WS.replace('{wrapper}', encodeURIComponent(vars.wrapperStr));
 				vars.change('createdURL', requestURL);
 				const res = await fetch(vars.createdURL);
 				if (res.status >= 200 && res.status < 300) {

--- a/lib/vars.mjs
+++ b/lib/vars.mjs
@@ -46,14 +46,14 @@ const vars = {
     csStr: "&cs={cs}",
     apiKey: "{apikey}",
     input: "{input}",
-    wrapper: "{wrapper}",
+    wrapper: "&wrapper={wrapper}",
     wrapperStr: "@FaurinFox/cleverbot",
     baseURL: "TBD",
     createdURL: "TBD",
     tweakStr: "&tweak{tweaknum}={tweakvalue}",
-    tweak1: "70",
-    tweak2: "50",
-    tweak3: "50",
+    tweak1: 70,
+    tweak2: 50,
+    tweak3: 50,
     change: function(key, value) {
         if (vars[key] !== undefined) {
             vars[key] = value;
@@ -76,6 +76,9 @@ const vars = {
                 case "keyNotFound":
                     throw new Error(this.keyNotFound.replace('{keyname}', v));
                     break;
+                case "invalidTweak":
+                    throw new Error(this.keyNotFound.replace('{tweakname}', v));
+                    break;
                 case "optionsNotObj":
                     throw new Error(this.optionsNotObj);
                     break;
@@ -93,7 +96,8 @@ const vars = {
                     break;
             }
         },
-        "keyNotFound": "Change' function: Provided key '{keyname}' not found.",
+        "keyNotFound": "'Change' function: Provided key '{keyname}' not found.",
+        "invalidTweak": "Invalid tweak '{tweakname}' was provided.",
         "optionsNotObj": "Cleverbot: Options argument provided, but it is not an object.",
         "optionsObjKeyNotString": "Cleverbot: Options object provided, but the '{keyname}' key is not a string.",
         "optionsObjKeyNotNumber": "Cleverbot: Options object provided, but the '{keyname}' key is not a number.",
@@ -102,6 +106,6 @@ const vars = {
     }
 }
 
-vars.change("baseURL", "https://www.cleverbot.com/getreply?key="+vars.apiKey+"&input="+vars.input+"&wrapper="+vars.wrapper);
+vars.change("baseURL", "https://www.cleverbot.com/getreply?key="+vars.apiKey+"&input="+vars.input);
 
 export default vars;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@faurinfox/cleverbot",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@faurinfox/cleverbot",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "GPLV3",
       "dependencies": {
         "node-fetch": "^3.3.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "engines": {
-    "node": ">=12.20.0 <18.15.0"
+    "node": ">=12.20.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@faurinfox/cleverbot",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Provides a wrapper/client for the official Cleverbot API",
   "main": "index.mjs",
   "type": "module",


### PR DESCRIPTION
This also changes the tweaks pre-defined in vars.mjs to be type of Number rather than the string they were previously. It seems there was no real reason for them to have been strings, thus changing that makes them more in-line with the requirements to use them.

The Cleverbot-class now hosts the non-query related tweak functions. It may, or may not, be moved into its own file later on.

Readme.md was modified to explain a little how that setTweak function works.

Version was also updated to 1.2.0